### PR TITLE
Fix: Update Dockerfile to use Python 3.9

### DIFF
--- a/dagster_multi_etl/Dockerfile
+++ b/dagster_multi_etl/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Set the working directory in the container
 WORKDIR /opt/dagster/app


### PR DESCRIPTION
The previous Dockerfile used Python 3.8, which caused a conflict with your project dependencies requiring Python 3.9 or newer.

This commit updates the base image in the Dockerfile to `python:3.9-slim` to resolve the installation error during `docker-compose build`.